### PR TITLE
Fix Production Deploy Workflow

### DIFF
--- a/.github/workflows/prod-cf-deploy-lambda.yml
+++ b/.github/workflows/prod-cf-deploy-lambda.yml
@@ -17,7 +17,11 @@ defaults:
 
 jobs:
   deploy-lambda:
-    if: github.ref == 'refs/heads/main'
+    # We need to restrict this workflow to only run on releases on the main
+    # branch while also allowing for manual runs in the GitHub web UI. The
+    # GitHub context is different between releases and commits, so we have
+    # to check two different values before we decide to run this.
+    if: ${{ github.ref == 'refs/heads/main' || github.event.release.target_commitish == 'main' }}
     name: Push zip to S3 and Deploy CloudFront Distribution
     uses: mitlibraries/.github/.github/workflows/cf-lambda-shared-deploy.yml@main
     secrets: inherit

--- a/.github/workflows/stage-cf-deploy-lambda.yml
+++ b/.github/workflows/stage-cf-deploy-lambda.yml
@@ -18,7 +18,10 @@ defaults:
     shell: bash
 
 jobs:
-  deploy-lambda:
+  deploy-lambda:   
+  # We need to restrict this workflow to only run on the main branch whether
+  # it's through automation or through a manual trigger in the web UI.
+    if: ${{ github.ref == 'refs/heads/main' }}
     name: Push zip to S3 and Deploy CloudFront Distribution
     uses: mitlibraries/.github/.github/workflows/cf-lambda-shared-deploy.yml@main
     secrets: inherit


### PR DESCRIPTION
### Purpose and background context

The `prod-cf-deploy-lambda.yml` workflow did not work correctly on the first tagged release. Turns out that I had not fully understood what the GitHub context looked like and the `if:` statement for the job was incorrect. This addresses that problem.

The GHA Context is documented at [learn-github-actions/contexts](https://docs.github.com/en/actions/learn-github-actions/contexts). The GitHub REST API documentation is at [releases?apiVersion=2022-11-28](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28).

#### How this addresses the issue

* Correct the `if:` test at the start of the job to correctly identify if the trigger is a release on `main` or if it's a workflow_dispatch from the GitHub web UI.
* This also updates the stage deploy workflow to be restricted to the `main` branch for any `workflow_dispatch` triggers (thus preventing any feature branch from being force deployed to Stage-Workloads)

### How can a reviewer manually see the effects of these changes?

Not easily! I have a personal repo (where I break as many "rules" as possible while testing things) that has a number of recent commits on the `main` branch and some Actions that were run to test this all out. It's ugly, but it does demonstrate that this logic should work correctly. The repo and actions are here: [git-flow-test/actions](https://github.com/cabutlermit/git-flow-test/actions)

### Includes new or updated dependencies?

NO

### Changes expectations for external applications?

NO

### Developer

- [N/A] The `Dev CF Lambda@Edge Full Deploy` workflow has been run to update CloudFront in Dev1
- [N/A] All related Jira tickets are linked in commit message(s)
- [N/A] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)

- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no changes